### PR TITLE
Handling platform errors. Unifying droid and iOS error codes

### DIFF
--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -357,7 +357,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
 
             val contentResolver: ContentResolver? = _context?.getContentResolver()
             if (isRecurringEvent(eventIdNumber, contentResolver)) {
-                finishWithError(NOT_FOUND, DELETING_RECURRING_EVENT_NOT_SUPPORTED_MESSAGE, pendingChannelResult)
+                finishWithError(NOT_ALLOWED, DELETING_RECURRING_EVENT_NOT_SUPPORTED_MESSAGE, pendingChannelResult)
                 return
             }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -20,7 +20,6 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTIO
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_ID_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_TITLE_INDEX
 import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.NOT_FOUND
-import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.EXCEPTION
 import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.INVALID_ARGUMENT
 import com.builttoroam.devicecalendar.models.Calendar
 import com.builttoroam.devicecalendar.models.Event
@@ -187,7 +186,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
 
                 finishWithSuccess(_gson?.toJson(calendars), pendingChannelResult)
             } catch (e: Exception) {
-                finishWithError(EXCEPTION, e.message, pendingChannelResult)
+                finishWithError(GENERIC_ERROR, e.message, pendingChannelResult)
                 println(e.message)
             } finally {
                 cursor?.close()
@@ -278,7 +277,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
                     updateEventAttendees(events, contentResolver, pendingChannelResult)
                 }
             } catch (e: Exception) {
-                finishWithError(EXCEPTION, e.message, pendingChannelResult)
+                finishWithError(GENERIC_ERROR, e.message, pendingChannelResult)
                 println(e.message)
             } finally {
                 eventsCursor?.close()
@@ -326,7 +325,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
 
                 finishWithSuccess(eventId.toString(), pendingChannelResult)
             } catch (e: Exception) {
-                finishWithError(EXCEPTION, e.message, pendingChannelResult)
+                finishWithError(GENERIC_ERROR, e.message, pendingChannelResult)
                 println(e.message)
             } finally {
             }
@@ -531,7 +530,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
                 } while (attendeesCursor?.moveToNext() ?: false)
             }
         } catch (e: Exception) {
-            finishWithError(EXCEPTION, e.message, pendingChannelResult)
+            finishWithError(GENERIC_ERROR, e.message, pendingChannelResult)
             println(e.message)
         } finally {
             attendeesCursor?.close();

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/CalendarDelegate.kt
@@ -19,11 +19,9 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.CALENDAR_PROJEC
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_DESCRIPTION_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_ID_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_TITLE_INDEX
-import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.CALENDAR_IS_READ_ONLY
-import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.CALENDAR_RETRIEVAL_FAILURE
+import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.NOT_FOUND
 import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.EXCEPTION
 import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.INVALID_ARGUMENT
-import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.CALENDAR_ID_INVALID_ARGUMENT_NOT_A_NUMBER_MESSAGE
 import com.builttoroam.devicecalendar.models.Calendar
 import com.builttoroam.devicecalendar.models.Event
 import io.flutter.plugin.common.MethodChannel
@@ -42,12 +40,11 @@ import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTIO
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_EVENT_LOCATION_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_RECURRING_DATE_INDEX
 import com.builttoroam.devicecalendar.common.Constants.Companion.EVENT_PROJECTION_RECURRING_RULE_INDEX
-import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.DELETING_RECURRING_EVENT_NOT_SUPPORTED
-import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.EVENTS_RETRIEVAL_FAILURE
-import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.EVENT_CREATION_FAILURE
+import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.GENERIC_ERROR
+import com.builttoroam.devicecalendar.common.ErrorCodes.Companion.NOT_ALLOWED
+import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.CALENDAR_ID_INVALID_ARGUMENT_NOT_A_NUMBER_MESSAGE
 import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.CREATE_EVENT_ARGUMENTS_NOT_VALID_MESSAGE
 import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.DELETING_RECURRING_EVENT_NOT_SUPPORTED_MESSAGE
-import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.EVENTS_START_DATE_LARGER_THAN_END_DATE_MESSAGE
 import com.builttoroam.devicecalendar.models.Attendee
 import com.builttoroam.devicecalendar.models.CalendarMethodsParametersCacheModel
 import java.util.*
@@ -227,7 +224,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
                     }
                 } else {
                     if (!isInternalCall) {
-                        finishWithError(CALENDAR_RETRIEVAL_FAILURE, "Couldn't retrieve the Calendar with ID ${calendarId}", pendingChannelResult)
+                        finishWithError(NOT_FOUND, "Couldn't retrieve the Calendar with ID ${calendarId}", pendingChannelResult)
                     }
                 }
             } catch (e: Exception) {
@@ -248,11 +245,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
         if (arePermissionsGranted()) {
             val calendar = retrieveCalendar(calendarId, pendingChannelResult, true)
             if (calendar == null) {
-                finishWithError(CALENDAR_RETRIEVAL_FAILURE, "Couldn't retrieve the Calendar with ID ${calendarId}", pendingChannelResult)
-                return
-            }
-            if (startDate > endDate) {
-                finishWithError(EVENTS_RETRIEVAL_FAILURE, EVENTS_START_DATE_LARGER_THAN_END_DATE_MESSAGE, pendingChannelResult)
+                finishWithError(NOT_FOUND, "Couldn't retrieve the Calendar with ID ${calendarId}", pendingChannelResult)
                 return
             }
 
@@ -304,7 +297,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
     public fun createOrUpdateEvent(calendarId: String, event: Event?, pendingChannelResult: MethodChannel.Result) {
         if (arePermissionsGranted()) {
             if (event == null) {
-                finishWithError(EVENT_CREATION_FAILURE, CREATE_EVENT_ARGUMENTS_NOT_VALID_MESSAGE, pendingChannelResult)
+                finishWithError(GENERIC_ERROR, CREATE_EVENT_ARGUMENTS_NOT_VALID_MESSAGE, pendingChannelResult)
                 return
             }
 
@@ -348,12 +341,12 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
         if (arePermissionsGranted()) {
             var existingCal = retrieveCalendar(calendarId, pendingChannelResult, true)
             if (existingCal == null) {
-                finishWithError(CALENDAR_RETRIEVAL_FAILURE, "Couldn't retrieve the Calendar with ID ${calendarId}", pendingChannelResult)
+                finishWithError(NOT_FOUND, "Couldn't retrieve the Calendar with ID ${calendarId}", pendingChannelResult)
                 return
             }
 
             if (existingCal.isReadyOnly) {
-                finishWithError(CALENDAR_IS_READ_ONLY, "Calendar with ID ${calendarId} is read only", pendingChannelResult)
+                finishWithError(NOT_ALLOWED, "Calendar with ID ${calendarId} is read only", pendingChannelResult)
                 return
             }
 
@@ -365,7 +358,7 @@ public class CalendarDelegate : PluginRegistry.RequestPermissionsResultListener 
 
             val contentResolver: ContentResolver? = _context?.getContentResolver()
             if (isRecurringEvent(eventIdNumber, contentResolver)) {
-                finishWithError(DELETING_RECURRING_EVENT_NOT_SUPPORTED, DELETING_RECURRING_EVENT_NOT_SUPPORTED_MESSAGE, pendingChannelResult)
+                finishWithError(NOT_FOUND, DELETING_RECURRING_EVENT_NOT_SUPPORTED_MESSAGE, pendingChannelResult)
                 return
             }
 

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/DeviceCalendarPlugin.kt
@@ -2,10 +2,6 @@ package com.builttoroam.devicecalendar
 
 import android.app.Activity
 import android.content.Context
-import com.builttoroam.devicecalendar.common.ErrorCodes
-import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.CALENDAR_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE
-import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.CREATE_EVENT_ARGUMENTS_NOT_VALID_MESSAGE
-import com.builttoroam.devicecalendar.common.ErrorMessages.Companion.EVENT_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE
 import com.builttoroam.devicecalendar.models.Event
 
 import io.flutter.plugin.common.MethodChannel
@@ -80,11 +76,8 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                 val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
                 val startDate = call.argument<Long>(CALENDAR_EVENTS_START_DATE_ARGUMENT)
                 val endDate = call.argument<Long>(CALENDAR_EVENTS_END_DATE_ARGUMENT)
-                if (calendarId == null || calendarId.isEmpty()) {
-                    result.error(ErrorCodes.INVALID_ARGUMENT, CALENDAR_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE, null)
-                } else {
-                    _calendarDelegate.retrieveEvents(calendarId, startDate, endDate, result)
-                }
+
+                _calendarDelegate.retrieveEvents(calendarId, startDate, endDate, result)
             }
             CREATE_OR_UPDATE_EVENT_METHOD -> {
                 val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
@@ -93,11 +86,6 @@ class DeviceCalendarPlugin() : MethodCallHandler {
                 val eventDescription = call.argument<String>(EVENT_DESCRIPTION_ARGUMENT)
                 val eventStart = call.argument<Long>(EVENT_START_DATE_ARGUMENT)
                 val eventEnd = call.argument<Long>(EVENT_END_DATE_ARGUMENT)
-
-                if (calendarId == null || calendarId.isEmpty() || eventTitle == null || eventTitle.isEmpty()) {
-                    result.error(ErrorCodes.INVALID_ARGUMENT, CREATE_EVENT_ARGUMENTS_NOT_VALID_MESSAGE, null)
-                    return
-                }
 
                 val event = Event(eventTitle)
                 event.calendarId = calendarId
@@ -111,14 +99,6 @@ class DeviceCalendarPlugin() : MethodCallHandler {
             DELETE_EVENT_METHOD -> {
                 val calendarId = call.argument<String>(CALENDAR_ID_ARGUMENT)
                 val eventId = call.argument<String>(EVENT_ID_ARGUMENT)
-                if (calendarId == null || calendarId.isEmpty()) {
-                    result.error(ErrorCodes.INVALID_ARGUMENT, CALENDAR_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE, null)
-                    return
-                }
-                if (eventId == null || eventId.isEmpty()) {
-                    result.error(ErrorCodes.INVALID_ARGUMENT, EVENT_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE, null)
-                    return
-                }
 
                 _calendarDelegate.deleteEvent(calendarId, eventId, result)
             }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/ErrorCodes.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/ErrorCodes.kt
@@ -2,7 +2,6 @@ package com.builttoroam.devicecalendar.common
 
 class ErrorCodes {
     companion object {
-        const val EXCEPTION: String = "exception"
         const val INVALID_ARGUMENT: String = "400"
         const val NOT_FOUND: String = "404"
         const val NOT_ALLOWED: String = "405"

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/ErrorCodes.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/ErrorCodes.kt
@@ -3,11 +3,9 @@ package com.builttoroam.devicecalendar.common
 class ErrorCodes {
     companion object {
         const val EXCEPTION: String = "exception"
-        const val INVALID_ARGUMENT: String = "invalid_argument"
-        const val CALENDAR_RETRIEVAL_FAILURE: String = "calendar_retrieval_failure"
-        const val EVENTS_RETRIEVAL_FAILURE: String = "events_retrieval_failure"
-        const val EVENT_CREATION_FAILURE: String = "event_creation_failure"
-        const val CALENDAR_IS_READ_ONLY: String = "calendar_is_read_only"
-        const val DELETING_RECURRING_EVENT_NOT_SUPPORTED: String = "deleting_recurring_event_not_supported"
+        const val INVALID_ARGUMENT: String = "400"
+        const val NOT_FOUND: String = "404"
+        const val NOT_ALLOWED: String = "405"
+        const val GENERIC_ERROR: String = "500"
     }
 }

--- a/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/ErrorMessages.kt
+++ b/device_calendar/android/src/main/kotlin/com/builttoroam/devicecalendar/common/ErrorMessages.kt
@@ -3,10 +3,6 @@ package com.builttoroam.devicecalendar.common
 class ErrorMessages {
     companion object {
         const val CALENDAR_ID_INVALID_ARGUMENT_NOT_A_NUMBER_MESSAGE: String = "Calendar ID is not a number"
-        const val CALENDAR_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE: String = "Calendar ID argument has not been specified or is invalid"
-        const val EVENT_ID_INVALID_ARGUMENT_NOT_SPECIFIED_MESSAGE: String = "Event ID argument has not been specified or is invalid"
-        const val EVENT_ID_INVALID_ARGUMENT_NOT_A_NUMBER_MESSAGE: String = "Event ID is not a number"
-        const val EVENTS_START_DATE_LARGER_THAN_END_DATE_MESSAGE: String = "The starting date needs to be lower than the end date"
         const val CREATE_EVENT_ARGUMENTS_NOT_VALID_MESSAGE: String = "Some of the event arguments are not valid"
         const val DELETING_RECURRING_EVENT_NOT_SUPPORTED_MESSAGE: String = "Currently, deleting of recurring events is not supported"
     }

--- a/device_calendar/example/lib/presentation/event_item.dart
+++ b/device_calendar/example/lib/presentation/event_item.dart
@@ -161,11 +161,11 @@ class EventItem extends StatelessWidget {
                                 onPressed: () async {
                                   Navigator.of(context).pop();
                                   _onLoadingStarted();
-                                  final deleteSucceeded =
+                                  final deleteResult =
                                       await _deviceCalendarPlugin.deleteEvent(
                                           _calendarEvent.calendarId,
                                           _calendarEvent.eventId);
-                                  _onDeleteFinished(deleteSucceeded);
+                                  _onDeleteFinished(deleteResult.isSuccess && deleteResult.data);
                                 },
                                 child: new Text('Ok'),
                               ),

--- a/device_calendar/example/lib/presentation/pages/calendar_events.dart
+++ b/device_calendar/example/lib/presentation/pages/calendar_events.dart
@@ -118,10 +118,10 @@ class _CalendarEventsPageState extends State<CalendarEventsPage> {
   Future _retrieveCalendarEvents() async {
     var startDate = new DateTime.now().add(new Duration(days: -30));
     var endDate = new DateTime.now().add(new Duration(days: 30));
-    var calendarEvents = await _deviceCalendarPlugin.retrieveEvents(
+    var calendarEventsResult = await _deviceCalendarPlugin.retrieveEvents(
         _calendar.id, startDate, endDate);
     setState(() {
-      _calendarEvents = calendarEvents;
+      _calendarEvents = calendarEventsResult?.data;
       _isLoading = false;
     });
   }

--- a/device_calendar/example/lib/presentation/pages/calendars.dart
+++ b/device_calendar/example/lib/presentation/pages/calendars.dart
@@ -78,9 +78,9 @@ class _CalendarsPageState extends State<CalendarsPage> {
         }
       }
 
-      final calendars = await _deviceCalendarPlugin.retrieveCalendars();
+      final calendarsResult = await _deviceCalendarPlugin.retrieveCalendars();
       setState(() {
-        _calendars = calendars;
+        _calendars = calendarsResult?.data;
       });
     } on PlatformException catch (e) {
       print(e);

--- a/device_calendar/example/lib/presentation/pages/calendars.dart
+++ b/device_calendar/example/lib/presentation/pages/calendars.dart
@@ -56,7 +56,9 @@ class _CalendarsPageState extends State<CalendarsPage> {
                                   style: new TextStyle(fontSize: 25.0),
                                 ),
                               ),
-                              new Icon(_calendars[index].isReadyOnly ? Icons.lock : Icons.lock_open)
+                              new Icon(_calendars[index].isReadyOnly
+                                  ? Icons.lock
+                                  : Icons.lock_open)
                             ],
                           )));
                 },
@@ -69,10 +71,9 @@ class _CalendarsPageState extends State<CalendarsPage> {
   void _retrieveCalendars() async {
     try {
       var permissionsGranted = await _deviceCalendarPlugin.hasPermissions();
-      if (!permissionsGranted) {
-        var permissionsGranted =
-            await _deviceCalendarPlugin.requestPermissions();
-        if (!permissionsGranted) {
+      if (permissionsGranted.isSuccess && !permissionsGranted.data) {
+        permissionsGranted = await _deviceCalendarPlugin.requestPermissions();
+        if (permissionsGranted.isSuccess && !permissionsGranted.data) {
           return;
         }
       }

--- a/device_calendar/lib/device_calendar.dart
+++ b/device_calendar/lib/device_calendar.dart
@@ -4,7 +4,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/services.dart';
 
-import 'src/common/constants.dart';
+import 'src/common/error_messages.dart';
+import 'src/common/error_codes.dart';
 
 part 'src/models/attendee.dart';
 part 'src/models/calendar.dart';

--- a/device_calendar/lib/src/common/constants.dart
+++ b/device_calendar/lib/src/common/constants.dart
@@ -1,7 +1,0 @@
-class Constants {
-  static const String fromJsonMapIsNull = 'The json object is null';
-
-  static const String invalidArgument = 'Provided arguments are invalid';
-  static const String createOrUpdateEventArgumentRequirements =
-      'To create or update an event you must provide calendar id, event with title, start date and end date (where start date must be before end date)';
-}

--- a/device_calendar/lib/src/common/error_codes.dart
+++ b/device_calendar/lib/src/common/error_codes.dart
@@ -1,0 +1,3 @@
+class ErrorCodes {
+  static const int invalidArguments = 400;
+}

--- a/device_calendar/lib/src/common/error_messages.dart
+++ b/device_calendar/lib/src/common/error_messages.dart
@@ -1,0 +1,10 @@
+class ErrorMessages {
+  static const String fromJsonMapIsNull = "The json object is null";
+
+  static const String retrieveEventsInvalidArgumentsMessage =
+      "Calendar ID argument have not been specified or is invalid";
+  static const String deleteEventInvalidArgumentsMessage =
+      "Calendar ID and/or Event ID argument(s) have not been specified or are invalid";
+  static const String createOrUpdateEventInvalidArgumentsMessage =
+      "To create or update an event you must provide calendar ID, event with a title and event's start date and end date (where start date must be before end date)";
+}

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -15,15 +15,37 @@ class DeviceCalendarPlugin {
   DeviceCalendarPlugin._createInstance();
 
   /// Requests permissions to modify the calendars on the device
-  Future<bool> requestPermissions() async {
-    var permissionsGranted = await channel.invokeMethod('requestPermissions');
-    return permissionsGranted;
+  Future<Result<bool>> requestPermissions() async {
+    var res = new Result(false);
+    
+    try {
+      var permissionsGranted = await channel.invokeMethod('requestPermissions');
+
+      res.isSuccess = true;
+      res.data = permissionsGranted;
+    } on PlatformException catch (e) {
+      _parsePlatformExceptionAndUpdateResult<bool>(e, res);
+      print(e);
+    }
+
+    return res;
   }
 
   /// Checks if permissions for modifying the device calendars have been granted
-  Future<bool> hasPermissions() async {
-    var permissionsGranted = await channel.invokeMethod('hasPermissions');
-    return permissionsGranted;
+  Future<Result<bool>> hasPermissions() async {
+    var res = new Result(false);
+
+    try {
+      var permissionsGranted = await channel.invokeMethod('hasPermissions');
+
+      res.isSuccess = true;
+      res.data = permissionsGranted;
+    } on PlatformException catch (e) {
+      _parsePlatformExceptionAndUpdateResult<bool>(e, res);
+      print(e);
+    }
+
+    return res;
   }
 
   /// Retrieves all of the device defined calendars
@@ -84,8 +106,8 @@ class DeviceCalendarPlugin {
   /// Creates or updates an event
   ///
   /// returns: event ID
-  Future<BaseResult<String>> createOrUpdateEvent(Event event) async {
-    var res = new BaseResult<String>(null);
+  Future<Result<String>> createOrUpdateEvent(Event event) async {
+    var res = new Result<String>(null);
     if ((event.calendarId?.isEmpty ?? true) ||
         (event?.title?.isEmpty ?? false) ||
         event.start == null ||
@@ -114,5 +136,15 @@ class DeviceCalendarPlugin {
     }
 
     return res;
+  }
+
+  void _parsePlatformExceptionAndUpdateResult<T>(
+      PlatformException exception, Result<T> result) {
+    if (exception == null || result == null) {
+      return;
+    }
+
+    result.errorMessages.add(
+        "Device calendar plugin ran into an issue. Platform specific exception [${exception.code}], with message :\"${exception.message}\", has been thrown.");
   }
 }

--- a/device_calendar/lib/src/device_calendar.dart
+++ b/device_calendar/lib/src/device_calendar.dart
@@ -69,6 +69,12 @@ class DeviceCalendarPlugin {
       String calendarId, DateTime startDate, DateTime endDate) async {
     final res = new Result(new List<Event>());
 
+    if ((calendarId?.isEmpty ?? true)) {
+      res.errorMessages.add(
+          "[${ErrorCodes.invalidArguments}] ${ErrorMessages.retrieveEventsInvalidArgumentsMessage}");
+      return res;
+    }
+
     try {
       var eventsJson =
           await channel.invokeMethod('retrieveEvents', <String, Object>{
@@ -93,6 +99,12 @@ class DeviceCalendarPlugin {
   Future<Result<bool>> deleteEvent(String calendarId, String eventId) async {
     final res = new Result(false);
 
+    if ((calendarId?.isEmpty ?? true) || (eventId?.isEmpty ?? true)) {
+      res.errorMessages.add(
+          "[${ErrorCodes.invalidArguments}] ${ErrorMessages.deleteEventInvalidArgumentsMessage}");
+      return res;
+    }
+
     try {
       res.data = await channel.invokeMethod('deleteEvent',
           <String, Object>{'calendarId': calendarId, 'eventId': eventId});
@@ -111,14 +123,13 @@ class DeviceCalendarPlugin {
   Future<Result<String>> createOrUpdateEvent(Event event) async {
     final res = new Result<String>(null);
 
-    if ((event.calendarId?.isEmpty ?? true) ||
-        (event?.title?.isEmpty ?? false) ||
+    if ((event?.calendarId?.isEmpty ?? true) ||
+        (event?.title?.isEmpty ?? true) ||
         event.start == null ||
         event.end == null ||
         event.start.isAfter(event.end)) {
-      res.errorMessages.add(Constants.invalidArgument);
-      res.errorMessages.add(Constants.createOrUpdateEventArgumentRequirements);
-
+      res.errorMessages.add(
+          "[${ErrorCodes.invalidArguments}] ${ErrorMessages.createOrUpdateEventInvalidArgumentsMessage}");
       return res;
     }
 

--- a/device_calendar/lib/src/models/attendee.dart
+++ b/device_calendar/lib/src/models/attendee.dart
@@ -9,7 +9,7 @@ class Attendee {
 
   Attendee.fromJson(Map<String, dynamic> json) {
     if (json == null) {
-      throw new ArgumentError(Constants.fromJsonMapIsNull);
+      throw new ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
 
     name = json['name'];

--- a/device_calendar/lib/src/models/event.dart
+++ b/device_calendar/lib/src/models/event.dart
@@ -33,7 +33,7 @@ class Event {
 
   Event.fromJson(Map<String, dynamic> json) {
     if (json == null) {
-      throw new ArgumentError(Constants.fromJsonMapIsNull);
+      throw new ArgumentError(ErrorMessages.fromJsonMapIsNull);
     }
 
     eventId = json['eventId'];

--- a/device_calendar/lib/src/models/results/base_result.dart
+++ b/device_calendar/lib/src/models/results/base_result.dart
@@ -1,9 +1,9 @@
 part of device_calendar;
 
-class BaseResult<T> {
+class Result<T> {
   bool isSuccess = false;
   T data;
   List<String> errorMessages = new List<String>();
 
-  BaseResult([this.data]);
+  Result([this.data]);
 }


### PR DESCRIPTION
You might want to add NOT_ALLOWED error code to iOS and handle the isReadOnly flag for the calendar, when user tries to do a CRUD operation on the calendar